### PR TITLE
Handle empty targets case

### DIFF
--- a/build.py
+++ b/build.py
@@ -458,7 +458,7 @@ def run() -> None:
         sys.exit(1)
 
     # Strip argparse sentinel
-    if '--' in args.target and not args.target[0]:
+    if args.target and args.target[0] == "--":
         args.target = args.target[1:]
 
     # Locate CMake
@@ -507,7 +507,8 @@ def run() -> None:
         else:
             add_arg(build_cmd, '--parallel')
 
-    add_arg(build_cmd, '--target', args.target)
+    if args.target:
+        add_arg(build_cmd, '--target', args.target)
 
     if args.verbose == 0:
         add_arg(build_cmd, '--', '--quiet')


### PR DESCRIPTION
Support the case when no explicit targets request was passed (build all, similar to "ninja" or "make" run without any target specification)